### PR TITLE
Update CI checkout action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     name: Contracts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 


### PR DESCRIPTION
## What changed

- Updated `actions/checkout` from v4 to v6 in the gateway build workflow.
- Updated `actions/checkout` from v4 to v6 in the contracts test workflow.
- Left the existing Bun and Foundry setup actions on their current major versions.

## Why

Checkout v6 uses the current Node.js 24 runtime and improves credential handling by storing persisted credentials outside `.git/config`.

## Impact

No application or contract code changes. CI checkout behavior remains compatible while using the latest major release.

## Validation

- `git diff --check`
- Verified the commit contains only `.github/workflows/build.yml` and `.github/workflows/test.yml`.
